### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lean]
+max_line_length = 100


### PR DESCRIPTION
Implements configuration from `.vscode/settings.json` in a mostly
editor-agnostic way.
