### PR TITLE
bump upload-artifact from deprecated v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: zip game.zip * .lake/ .i18n/ -r
 
       - name: upload compressed game folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-for-server-import
           path: |


### PR DESCRIPTION
Corresponding [blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) for this change
